### PR TITLE
バグ修正(Python3.9系)+OPCODEに 'SHL', 'SHR', 'SAR'を追加

### DIFF
--- a/octopus/arch/evm/emulator.py
+++ b/octopus/arch/evm/emulator.py
@@ -231,6 +231,7 @@ class EvmEmulatorEngine(EmulatorEngine):
         return halt
 
     def emul_arithmetic_instruction(self, instr, state):
+        global args
 
         if instr.name in ['ADD', 'SUB', 'MUL', 'DIV', 'MOD', 'SDIV', 'SMOD', 'EXP', 'SIGNEXTEND']:
             args = [state.ssa_stack.pop(), state.ssa_stack.pop()]
@@ -249,9 +250,10 @@ class EvmEmulatorEngine(EmulatorEngine):
             state.stack.append(result)
 
     def emul_comparaison_logic_instruction(self, instr, state):
+        global args
 
         if instr.name in ['LT', 'GT', 'SLT', 'SGT',
-                          'EQ', 'AND', 'OR', 'XOR', 'BYTE']:
+                          'EQ', 'AND', 'OR', 'XOR', 'BYTE', 'SHL', 'SHR', 'SAR']:
             args = [state.ssa_stack.pop(), state.ssa_stack.pop()]
         elif instr.name in ['ISZERO', 'NOT']:
             args = [state.ssa_stack.pop()]

--- a/octopus/arch/evm/evm.py
+++ b/octopus/arch/evm/evm.py
@@ -26,6 +26,9 @@ _table = {
     0x18: ('XOR', 0, 2, 1, 3, 'Bitwise XOR operation.'),
     0x19: ('NOT', 0, 1, 1, 3, 'Bitwise NOT operation.'),
     0x1a: ('BYTE', 0, 2, 1, 3, 'Retrieve single byte from word.'),
+    0x1b: ('SHL', 0, 2, 1, 3, '256bit shift left.'),
+    0x1c: ('SHR', 0, 2, 1, 3, '256bit shift right.'),
+    0x1d: ('SAR', 0, 2, 1, 3, 'int256 shift right.'),
     0x20: ('SHA3', 0, 2, 1, 30, 'Compute Keccak-256 hash.'),  # SHA3
     0x30: ('ADDRESS', 0, 0, 1, 2, 'Get address of currently executing account.'),
     0x31: ('BALANCE', 0, 1, 1, 20, 'Get balance of the given account.'),

--- a/octopus/arch/evm/ssa.py
+++ b/octopus/arch/evm/ssa.py
@@ -1,5 +1,5 @@
 from octopus.engine.helper import helper as hlp
-from z3 import UDiv, ULT, UGT
+import z3
 
 from logging import getLogger
 logging = getLogger(__name__)
@@ -89,7 +89,7 @@ class EvmSSASimplifier(object):
         if values[1] == 0:
             return 0
         else:
-            return hlp.get_concrete_int(UDiv(values[0] / values[1]))
+            return hlp.get_concrete_int(z3.UDiv(values[0] / values[1]))
 
     def operate_MOD(self, *values):
         return hlp.get_concrete_int(0 if values[1] == 0 else values[0] % values[1])
@@ -121,12 +121,12 @@ class EvmSSASimplifier(object):
     def operate_LT(self, *values):
         s0 = hlp.convert_to_bitvec(values[0])
         s1 = hlp.convert_to_bitvec(values[1])
-        return hlp.get_concrete_int(ULT(s0, s1))
+        return hlp.get_concrete_int(z3.ULT(s0, s1))
 
     def operate_GT(self, *values):
         s0 = hlp.convert_to_bitvec(values[0])
         s1 = hlp.convert_to_bitvec(values[1])
-        return hlp.get_concrete_int(UGT(s0, s1))
+        return hlp.get_concrete_int(z3.UGT(s0, s1))
 
     def operate_SLT(self, *values):
         s0 = hlp.convert_to_bitvec(values[0])


### PR DESCRIPTION
1. Python3.9系に対応できるようにライブラリの表記などを修正。
2. 対応できるOPCODEに'SHL', 'SHR', 'SAR'を追加
